### PR TITLE
Remove outSAMtype parameter

### DIFF
--- a/modules/02_star.nf
+++ b/modules/02_star.nf
@@ -28,7 +28,6 @@ process STAR {
     --outReadsUnmapped Fastx \
     --outFilterMismatchNoverLmax 0.02 \
     --runThreadN ${task.cpus} \
-    --outSAMtype BAM SortedByCoordinate \
     --outFileNamePrefix ${name}.
 
     mv ${name}.Aligned.sortedByCoord.out.bam ${name}.bam
@@ -67,7 +66,6 @@ process STAR_SE {
     --outReadsUnmapped Fastx \
     --outFilterMismatchNoverLmax 0.02 \
     --runThreadN ${task.cpus} \
-    --outSAMtype BAM SortedByCoordinate \
     --outFileNamePrefix ${name}.
 
     mv ${name}.Aligned.sortedByCoord.out.bam ${name}.bam


### PR DESCRIPTION
Sorting the output BAM by coordinate can lead to errors, when the input fastq files are derived from coordinate sorted bam files (https://github.com/alexdobin/STAR/issues/289). Thus, suggesting to have the default unmapped and let the user decide. 