### PR TITLE
Define the STAR output as bam file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Optional input:
     * inception: if enabled it uses an inception, only valid for BWA aln, it requires a fast file system such as flash (default: false)
     * skip_trimming: skips the read trimming step
     * star_two_pass_mode: activates STAR two-pass mode, increasing sensitivity of novel junction discovery, recommended for RNA variant calling (default: false)
+    * star_sort_by_coordinate: Sort STAR output BAM file by coordinate (default: false)
     * additional_args: additional alignment arguments, only effective in BWA mem, BWA mem 2 and STAR (default: none) 
 
 Output:

--- a/modules/02_star.nf
+++ b/modules/02_star.nf
@@ -58,6 +58,7 @@ process STAR_SE {
 
     script:
     two_pass_mode_param = params.star_two_pass_mode ? "--twopassMode Basic" : ""
+    sort = params.star_sort_by_coordinate ? "SortedByCoordinate" : ""
     """
     STAR --genomeDir ${reference} ${two_pass_mode_param} ${params.additional_args} \
     --readFilesCommand "gzip -d -c -f" \
@@ -65,6 +66,7 @@ process STAR_SE {
     --outSAMmode Full \
     --outSAMattributes Standard \
     --outSAMunmapped None \
+    --outSAMtype BAM ${sort} \
     --outReadsUnmapped Fastx \
     --outFilterMismatchNoverLmax 0.02 \
     --runThreadN ${task.cpus} \

--- a/modules/02_star.nf
+++ b/modules/02_star.nf
@@ -72,7 +72,7 @@ process STAR_SE {
     --runThreadN ${task.cpus} \
     --outFileNamePrefix ${name}.
 
-    mv ${name}.Aligned.sortedByCoord.out.bam ${name}.bam
+    mv ${name}.Aligned*.out.bam ${name}.bam
 
     echo ${params.manifest} >> software_versions.STAR_SE.txt
     STAR --version >> software_versions.STAR_SE.txt

--- a/modules/02_star.nf
+++ b/modules/02_star.nf
@@ -18,6 +18,7 @@ process STAR {
 
     script:
     two_pass_mode_param = params.star_two_pass_mode ? "--twopassMode Basic" : ""
+    sort = params.star_sort_by_coordinate ? "SortedByCoordinate" : ""
     """
     STAR --genomeDir ${reference} ${two_pass_mode_param} ${params.additional_args} \
     --readFilesCommand "gzip -d -c -f" \
@@ -25,12 +26,13 @@ process STAR {
     --outSAMmode Full \
     --outSAMattributes Standard \
     --outSAMunmapped None \
+    --outSAMtype BAM ${sort} \
     --outReadsUnmapped Fastx \
     --outFilterMismatchNoverLmax 0.02 \
     --runThreadN ${task.cpus} \
     --outFileNamePrefix ${name}.
 
-    mv ${name}.Aligned.sortedByCoord.out.bam ${name}.bam
+    mv ${name}.Aligned*.out.bam ${name}.bam
 
     echo ${params.manifest} >> software_versions.STAR.txt
     STAR --version >> software_versions.STAR.txt

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,6 +17,7 @@ params.memory = "32g"
 params.inception = false
 params.skip_trimming = false
 params.star_two_pass_mode = false
+params.star_sort_by_coordinate = false
 params.additional_args = ""
 params.fastp_args = ""
 


### PR DESCRIPTION
The STAR output file has to be a BAM file and no SAM file. 
This fixes the error that the sorted file is not found.

The change that sorting is not performed is required as if input fastq files were generated from already sorted bams the RAM usage is extremely high.