### PR TITLE
fixed issue in 03_index that required a sorted bam file before indexing

### DIFF
--- a/modules/02_star.nf
+++ b/modules/02_star.nf
@@ -18,7 +18,7 @@ process STAR {
 
     script:
     two_pass_mode_param = params.star_two_pass_mode ? "--twopassMode Basic" : ""
-    sort = params.star_sort_by_coordinate ? "SortedByCoordinate" : ""
+    sort = params.star_sort_by_coordinate ? "SortedByCoordinate" : "Unsorted"
     """
     STAR --genomeDir ${reference} ${two_pass_mode_param} ${params.additional_args} \
     --readFilesCommand "gzip -d -c -f" \

--- a/modules/03_index.nf
+++ b/modules/03_index.nf
@@ -16,7 +16,17 @@ process INDEX_BAM {
       file("software_versions.INDEX_BAM.txt")
 
     """
-    samtools index -@ ${task.cpus} ${bam}
+
+    samtools sort \
+    -@ ${task.cpus} \
+    -o ${name}.sorted.bam ${bam}
+
+    samtools index \
+    -@ ${task.cpus} ${name}.sorted.bam 
+
+    mv ${name}.sorted.bam.bai ${name}.bam.bai
+  
+    rm -f ${name}.sorted.bam
 
     echo ${params.manifest} >> software_versions.INDEX_BAM.txt
     samtools --version >> software_versions.INDEX_BAM.txt


### PR DESCRIPTION
Fixing issue where samtools index failed because of unsorted bam outputs from previous steps. Added a `samtools sort` step to fix the issue as well as cleaning steps for proper file naming.